### PR TITLE
Testit Serviceille ja routeille

### DIFF
--- a/src/__mocks__/axios.js
+++ b/src/__mocks__/axios.js
@@ -1,0 +1,4 @@
+export default {
+  post: jest.fn(() => Promise.resolve({ data: {} })),
+  get: jest.fn(() => Promise.resolve({ data: {} }))
+}

--- a/src/__mocks__/react-router-dom.js
+++ b/src/__mocks__/react-router-dom.js
@@ -1,0 +1,7 @@
+import React from 'react'
+const rrd = require('react-router-dom')
+
+// eslint-disable-next-line
+rrd.BrowserRouter = ({children}) => <div>{children}</div>
+// eslint-disable-next-line
+module.exports = rrd

--- a/src/app/components/Admin/index.js
+++ b/src/app/components/Admin/index.js
@@ -22,7 +22,7 @@ class AdminPage extends Component {
         {user
           ? (
             <div className="user-info">
-              <p>User id: {user.id}, User token: {user.token}</p>
+              <p>User id: {user.id}, User token: {false && user.token}</p>
               {!user.token ? <p>Käyttäjä ei ole rekisteröitynyt (Jos käyttäjällä token, on rekisteröitynyt)</p> : <p>Käyttäjä on rekisteröitynyt</p>}
             </div>
           )

--- a/src/app/components/common/AppBar.js
+++ b/src/app/components/common/AppBar.js
@@ -23,15 +23,21 @@ const styles = {
 export const ButtonAppBar = (props) => {
   return (
     <div className='appBar' style={styles.root}>
-      <AppBar position='static' className='appBar_material' style={[styles.root, { border: 'solid', borderColor: 'red' }]}>
-        <Toolbar className='toolbar_material'>
-          <IconButton onClick={props.toggleDrawer} className='appBar_menu_button' color='inherit' aria-label='Menu'>
-            <MenuIcon className='menuicon_material' />
-          </IconButton>
-          <Typography variant='title' color='inherit' className='typography'>
-            Aikavälikertaus
-          </Typography>
-          <Button onClick={() => console.log('login pressed')} color='inherit' className='appBar_login_button'>Login</Button>
+      <AppBar position='static' className='appBar_material'>
+        <Toolbar className='toolbar_material' style={{ flex: 1 }}>
+          <div style={{ flex: 0.1 }}>
+            <IconButton onClick={props.toggleDrawer} className='appBar_menu_button' color='inherit' aria-label='Menu'>
+              <MenuIcon className='menuicon_material' />
+            </IconButton>
+          </div>
+          <div style={{ flex: 0.8 }}>
+            <Typography variant='title' color='inherit' className='typography'>
+              Aikavälikertaus
+            </Typography>
+          </div>
+          <div style={{ flex: 0.1 }}>
+            <Button onClick={() => console.log('login pressed')} color='inherit' className='appBar_login_button'>Login</Button>
+          </div>
         </Toolbar>
       </AppBar>
     </div>

--- a/src/app/services/authService.js
+++ b/src/app/services/authService.js
@@ -7,6 +7,11 @@ const setToken = (newToken) => {
   token = `bearer ${newToken}`
 }
 
+// For tests
+const getToken = () => {
+  return token
+}
+
 const generateNewUnregisteredUser = async () => {
   // No need for config here. Just here to get lint through
   const config = {
@@ -16,4 +21,4 @@ const generateNewUnregisteredUser = async () => {
   return response.data
 }
 
-export default { generateNewUnregisteredUser, setToken }
+export default { generateNewUnregisteredUser, setToken, getToken }

--- a/src/app/services/questionService.js
+++ b/src/app/services/questionService.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 let token = null
 
 let baseUrl = ''
+// This can not be tested. It's ok tho
 if (process.env.NODE_ENV === 'production') {
   baseUrl = 'https://aikavali-back.herokuapp.com'
 }
@@ -10,6 +11,10 @@ const apiUrl = '/api/v1/questions'
 
 const setToken = (newToken) => {
   token = `bearer ${newToken}`
+}
+// For tests
+const getToken = () => {
+  return token
 }
 
 const getRandomQuestion = async () => {
@@ -20,4 +25,4 @@ const getRandomQuestion = async () => {
   return response.data
 }
 
-export default { getRandomQuestion, setToken }
+export default { getRandomQuestion, setToken, getToken }

--- a/src/tests/components/App/App.test.js
+++ b/src/tests/components/App/App.test.js
@@ -8,11 +8,17 @@ import authService from '../../../app/services/authService'
 import AppBar from '../../../app/components/common/AppBar'
 import TemporaryDrawer from '../../../app/components/common/TemporaryDrawer'
 import ButtonBar from '../../../app/components/common/ButtonBar'
+import { MemoryRouter } from 'react-router'
+import AdminPage from '../../../app/components/Admin'
 
 describe('<App />', () => {
   let app
   beforeAll(() => {
-    app = mount(<Provider store={store}><App /></Provider>)
+    app = mount(
+      <MemoryRouter initialEntries={[ '/' ]}>
+        <Provider store={store}><App /></Provider>
+      </MemoryRouter>
+    )
   })
   afterAll(() => {
     app.unMount()
@@ -38,5 +44,26 @@ describe('<App />', () => {
   it('renders ButtonBar', () => {
     const buttonBarComponents = app.find(ButtonBar)
     expect(buttonBarComponents.length).toBe(1)
+  })
+
+  /* ------------ ROUTES ------------- */
+
+  it('path \'/\' renders FrontPage', () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={[ '/' ]}>
+        <Provider store={store}><App /></Provider>
+      </MemoryRouter>
+    )
+    expect(wrapper.find(FrontPage).length).toBe(1)
+    expect(wrapper.find(AdminPage).length).toBe(0)
+  })
+  it('path \'/admin\' renders AdminPage', () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={[ '/admin' ]}>
+        <Provider store={store}><App /></Provider>
+      </MemoryRouter>
+    )
+    expect(wrapper.find(FrontPage).length).toBe(0)
+    expect(wrapper.find(AdminPage).length).toBe(1)
   })
 })

--- a/src/tests/components/common/AppBar.test.js
+++ b/src/tests/components/common/AppBar.test.js
@@ -28,7 +28,7 @@ describe('<AppBar />', () => {
     expect(typeof iconButtonProps.onClick).toBe('function')
     expect(appBar.find(MenuIcon).hasClass('menuicon_material')).toBe(true)
     const typographyComponent = appBar.find(Typography)
-    expect(typographyComponent.hasClass('Component-grow-02')).toBe(true)
+    expect(typographyComponent.hasClass('typography')).toBe(true)
     const typographyProps = typographyComponent.props()
     expect(typographyProps.variant).toBe('title')
     expect(typographyComponent.text()).toContain('Aikavälikertaus')

--- a/src/tests/services/authService.test.js
+++ b/src/tests/services/authService.test.js
@@ -1,0 +1,55 @@
+import mockAxios from 'axios'
+jest.unmock('../../app/services/authService')
+import authService from '../../app/services/authService'
+
+describe('authService', () => {
+  describe('generateNewUnregisteredUser', () => {
+    let newUser
+    beforeEach(() => {
+      mockAxios.post.mockImplementationOnce(() =>
+        Promise.resolve({
+          data: {
+            id: 123,
+            token: 567
+          }
+        })
+      )
+    })
+    it('calls axios post', async () => {
+      newUser = await authService.generateNewUnregisteredUser()
+      expect(mockAxios.post).toHaveBeenCalledTimes(1)
+    })
+    describe('calls axios post with /api/v1/user/generate and configs', () => {
+      it('when token is not set', async () => {
+        newUser = await authService.generateNewUnregisteredUser()
+        expect(mockAxios.post).toHaveBeenCalledWith(
+          '/api/v1/user/generate',
+          {
+            headers: { 'Authorization': null }
+          }
+        )
+      })
+      it('when token is set', async () => {
+        authService.setToken(1337)
+        newUser = await authService.generateNewUnregisteredUser()
+        expect(mockAxios.post).toHaveBeenCalledWith(
+          '/api/v1/user/generate',
+          {
+            headers: { 'Authorization': 'bearer 1337' }
+          }
+        )
+      })
+    })
+    it('returns user object from axios', async () => {
+      newUser = await authService.generateNewUnregisteredUser()
+      expect(newUser).toEqual({
+        id: 123,
+        token: 567
+      })
+    })
+  })
+  it ('sets token', () => {
+    authService.setToken(8783)
+    expect(authService.getToken()).toBe('bearer 8783')
+  })
+})

--- a/src/tests/services/questionService.test.js
+++ b/src/tests/services/questionService.test.js
@@ -1,0 +1,73 @@
+import mockAxios from 'axios'
+jest.unmock('../../app/services/questionService')
+import questionService from '../../app/services/questionService'
+
+describe('questionService', () => {
+  describe('getRandomQuestion', () => {
+    let question
+    beforeEach(() => {
+      mockAxios.get.mockImplementationOnce(() =>
+        Promise.resolve({
+          data: {
+            kind: 'CompileQuestion',
+            item: {
+              options: [
+                'if i > 1',
+                '(if) i > 1',
+                '(if i > 1)',
+                'if (i > 1) {}'
+              ]
+            },
+            _id: '5ba9d7b57cb50d03b2e4a9e3',
+            __v: 0
+          }
+        })
+      )
+    })
+    it('calls axios post', async () => {
+      question = await questionService.getRandomQuestion()
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    })
+    describe('calls axios get with /api/v1/questions/random and configs', () => {
+      it('when token is not set', async () => {
+        question = await questionService.getRandomQuestion()
+        expect(mockAxios.get).toHaveBeenCalledWith(
+          '/api/v1/questions/random',
+          {
+            headers: { 'Authorization': null }
+          }
+        )
+      })
+      it('when token is set', async () => {
+        questionService.setToken(1337)
+        question = await questionService.getRandomQuestion()
+        expect(mockAxios.get).toHaveBeenCalledWith(
+          '/api/v1/questions/random',
+          {
+            headers: { 'Authorization': 'bearer 1337' }
+          }
+        )
+      })
+    })
+    it('returns question object from axios', async () => {
+      question = await questionService.getRandomQuestion()
+      expect(question).toEqual({
+        kind: 'CompileQuestion',
+        item: {
+          options: [
+            'if i > 1',
+            '(if) i > 1',
+            '(if i > 1)',
+            'if (i > 1) {}'
+          ]
+        },
+        _id: '5ba9d7b57cb50d03b2e4a9e3',
+        __v: 0
+      })
+    })
+  })
+  it ('sets token', () => {
+    questionService.setToken(8783)
+    expect(questionService.getToken()).toBe('bearer 8783')
+  })
+})


### PR DESCRIPTION
AppBar:ssa olis hyvä saada kaikkien kolmen elementin (menubutton, typography ja login-button) flex-arvot 1. Ja sit sen laatikon SISÄISESTI asettaa menubutton vasemmalle, typography keskelle ja login-button oikealle). MUTTA koska niitä ei nyt jostain kumman syystä pysty ainakaan alignItems tai justifyContent propseilla muuttamaan, niin en tiedä sit !